### PR TITLE
Use Mycroft location coordinates if available

### DIFF
--- a/SunSkill/__init__.py
+++ b/SunSkill/__init__.py
@@ -40,10 +40,14 @@ class SunSkill(MycroftSkill):
 
         
         city = self.config_core.get("location")
-        geolocator = Nominatim()
-        location = geolocator.geocode(city)
-        lat = location.latitude
-        lon = location.longitude
+        if isinstance(city, str): # city is city name
+            geolocator = Nominatim()
+            location = geolocator.geocode(city)
+            lat = location.latitude
+            lon = location.longitude
+        else: # city is a dict of location information
+            lat = city['coordinate']['latitude']
+            lon = city['coordinate']['longitude']
         
 
         sun = SolarTime()


### PR DESCRIPTION
The location can be set on https://home.mycroft.ai and will then provide coordinates without using Nominatim. If the location is just a string without additional info, the previous behaviour is used.